### PR TITLE
Add isSome and isNone Type Guards

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,11 @@
 # TypeScript Nullable
 
-[![CircleCI](https://circleci.com/gh/kylecorbelli/typescript-nullable.svg?style=shield)](https://circleci.com/gh/kylecorbelli/typescript-nullable)
-
-[![codecov](https://codecov.io/gh/kylecorbelli/typescript-nullable/branch/master/graph/badge.svg)](https://codecov.io/gh/kylecorbelli/typescript-nullable)
+[![npm version](https://img.shields.io/npm/v/typescript-nullable.svg?style=shield)](https://www.npmjs.com/package/typescript-nullable) [![CircleCI](https://circleci.com/gh/kylecorbelli/typescript-nullable.svg?style=shield)](https://circleci.com/gh/kylecorbelli/typescript-nullable) [![codecov](https://codecov.io/gh/kylecorbelli/typescript-nullable/branch/master/graph/badge.svg)](https://codecov.io/gh/kylecorbelli/typescript-nullable)
 
 ## What is This?
 Glad you asked. This is a type-safe formalization of the concept of possibly absent values in TypeScript. It is perhaps even more importantly a module of type-safe utility functions that deal with possibly absent values.
 
-Think of it roughly like Haskell’s or Elm’s `Maybe` type and corresponding module of functions for dealing with `Maybe`. It is functional to its core, with typed and curried pure functions.
+Think of it roughly like a JavaScript-friendly version of Haskell’s or Elm’s `Maybe` type and corresponding module of functions for dealing with `Maybe`. It is functional to its core, with typed and curried pure functions.
 
 ## Installation
 From the command line:
@@ -27,19 +25,46 @@ type Nullable<T> = T | None
 ```
 
 ## Module Utility Functions
+This module also ships with a `Nullable` object that contains multiple useful functions for dealing with potentially absent values. Thus we have both a `Nullable` type and a `Nullable` object of utility functions.
+
 All utility functions are curried to the extent that their _final_ argument is optional. If a final argument is not provided, the function will return another function that expects that final argument.
 
 #### Nullable.isNone
-Determines if a provided `Nullable` is `None`.
+Determines if a provided `Nullable` is `None` and provides a type guard.
 ###### Type Annotation
 ```
-<T>(nullable: Nullable<T>): boolean
+<T>(nullable: Nullable<T>): nullable is None
 ```
 ###### Example Usage
 ```TypeScript
 Nullable.isNone('noob noob') // false
 Nullable.isNone(null) // true
 Nullable.isNone(undefined) // true
+
+const possiblyNullValue: Nullable<string> = 'noob noob'
+
+if (Nullable.isNone(possiblyNullValue)) {
+  // in this scope, TypeScript knows possiblyNullValue is a None
+}
+```
+
+#### Nullable.isSome
+Determines if a provided `Nullable` is a concrete value and provides a type guard.
+###### Type Annotation
+```
+<T>(nullable: Nullable<T>): nullable is T
+```
+###### Example Usage
+```TypeScript
+Nullable.isNone('noob noob') // true
+Nullable.isNone(null) // false
+Nullable.isNone(undefined) // false
+
+const possiblyNullValue: Nullable<string> = 'noob noob'
+
+if (Nullable.isSome(possiblyNullValue)) {
+  // in this scope, TypeScript knows possiblyNullValue is a concrete string
+}
 ```
 
 #### Nullable.map
@@ -100,7 +125,7 @@ const safeDivide = curry((a: number, b: number): Nullable<number> => {
 
 compose(
   Nullable.andThen(safeDivide(3)),
-  Nullable.andThen(safeDivide(0)),
+  Nullable.andThen(safeDivide(0)), // this line results in a None value so the rest of the composition chain passes along None without blowing up or throwing an exception
   Nullable.andThen(safeDivide(4)),
   safeDivide(2),
 )(32) // null

--- a/circle.yml
+++ b/circle.yml
@@ -3,5 +3,6 @@ machine:
     version: 8.4.0
 test:
   override:
+    - npm run lint
     - npm test -- --coverage
     - ~/typescript-nullable/node_modules/.bin/codecov -t $CODECOV_TOKEN

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-nullable",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "A TypeScript Nullable<T> Type and Monad Compliant Utility Functions",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -14,6 +14,35 @@ describe('the Nullable module', () => {
       expect(Nullable.isNone(null)).toBe(true)
       expect(Nullable.isNone('hi')).toBe(false)
     })
+
+    it('provides a typeguard', () => {
+      const handleNullable = (someNullable: Nullable<string>): string => {
+        if (!Nullable.isNone(someNullable)) {
+          return someNullable
+        }
+        return 'value was undefined'
+      }
+      expect(handleNullable('oooh wee!')).toBe('oooh wee!')
+      expect(handleNullable(null)).toBe('value was undefined')
+    })
+  })
+
+  describe('isSome', () => {
+    it('determines if a particular Nullable is a concrete value', () => {
+      expect(Nullable.isSome(null)).toBe(false)
+      expect(Nullable.isSome('hi')).toBe(true)
+    })
+
+    it('provides a typeguard', () => {
+      const handleNullable = (someNullable: Nullable<string>): string => {
+        if (Nullable.isSome(someNullable)) {
+          return someNullable
+        }
+        return 'value was undefined'
+      }
+      expect(handleNullable('oooh wee!')).toBe('oooh wee!')
+      expect(handleNullable(null)).toBe('value was undefined')
+    })
   })
 
   describe('Nullable.map', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,8 +2,11 @@ export type None = null | undefined
 
 export type Nullable<T> = T | None
 
-const isNone = <T>(nullable: Nullable<T>): boolean =>
+const isNone = <T>(nullable: Nullable<T>): nullable is None =>
   nullable === null || nullable === undefined
+
+const isSome = <T>(nullable: Nullable<T>): nullable is T =>
+  nullable !== null && nullable !== undefined
 
 const mapHelper = <A, B> (func: (val: A) => B, nullable: Nullable<A>): Nullable<B> =>
   nullable !== undefined && nullable !== null
@@ -75,6 +78,7 @@ export const Nullable = {
   andThen,
   ap,
   isNone,
+  isSome,
   map,
   maybe,
   withDefault,


### PR DESCRIPTION
- Adds `isSome` function.
- Adds unit tests for `isSome`.
- Adds type guards to both `isSome` and `isNone`.
- Updates README to reflect new `isSome` function, the type guards, and adds an NPM badge.
- Adds `npm run lint` to the CircleCI test sequence.